### PR TITLE
feat: Add --clear-history flag to clear user history

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A terminal-style browser extension that replaces your new tab page with a comman
 | `open settings`  | Open settings modal                           |
 | `open history`   | Show browsing history                         |
 | `search <query>` | Search Google for the query                   |
+| `--clear-history`| Clear all browsing history                    |
 | `<url>`          | Navigate to URL (auto-detects URLs)           |
 | `<text>`         | Search Google for text                        |
 
@@ -114,6 +115,13 @@ A terminal-style browser extension that replaces your new tab page with a comman
 | `create flow <id>` | Create a new flow (enter URLs, 'exit' to finish) |
 | `delete flow <id>` | Delete a flow                                    |
 | `--flow <id>`      | Open all URLs in a flow in new tabs              |
+
+### History Management
+
+| Command            | Description                                      |
+| ------------------ | ------------------------------------------------ |
+| `cd history`       | List browsing history                            |
+| `--clear-history`  | Clear all browsing history                       |
 
 ## Project Structure
 
@@ -189,6 +197,9 @@ browser> create flow morning
 
 browser> --flow morning
 # Opens all URLs in the 'morning' flow
+
+browser> --clear-history
+# Clears all browsing history
 ```
 
 ## Customization

--- a/scripts/newtab.js
+++ b/scripts/newtab.js
@@ -938,6 +938,18 @@ function executeCommand(command, commandLine, typedText) {
     clearTerminal();
     return;
   }
+
+  // Command: --clear-history - clear browser history
+  if (cmd === '--clear-history') {
+    if (chrome && chrome.history && chrome.history.deleteAll) {
+      chrome.history.deleteAll(() => {
+        displayMessage('Browsing history cleared successfully!');
+      });
+    } else {
+      displayMessage('Error: Unable to clear history. Make sure the extension has the necessary permissions.');
+    }
+    return;
+  }
   
   // Command: open - enhanced to work with paths
   if (cmd === 'open') {


### PR DESCRIPTION
# Clear Browsing History Feature

## Description
This PR adds a new `--clear-history` command to the CLI browser extension, allowing users to clear their browsing history directly from the terminal interface.

## Changes Made
- Added `--clear-history` command to clear browser history
- Implemented `chrome.history.deleteAll()` for history clearing
- Added success/error feedback messages
- Updated README.md with documentation for the new command

## How to Test
1. Open the extension in a new tab
2. Type `--clear-history` and press Enter
3. Verify that:
   - A success message appears
   - The browser's history is cleared
   - The `cd history` command shows no history items

## Screenshots
<img width="677" height="441" alt="image" src="https://github.com/user-attachments/assets/e85f74af-61fa-4cbf-a121-f5524910e65f" />


